### PR TITLE
Disable WebSocket TLS certificate verification

### DIFF
--- a/lib/solana_rpc_ruby/websocket_client.rb
+++ b/lib/solana_rpc_ruby/websocket_client.rb
@@ -42,7 +42,7 @@ module SolanaRpcRuby
       EM.run {
         # ping option sends some data to the server periodically, 
         # which prevents the connection to go idle.
-        ws ||= Faye::WebSocket::Client.new(@cluster, nil)
+        ws ||= Faye::WebSocket::Client.new(@cluster, nil, :tls => {:verify_peer => false})
         EM::PeriodicTimer.new(KEEPALIVE_TIME) do
           while !ws.ping
             @retries += 1


### PR DESCRIPTION
Wildcard certificates are not passing the TLS certificate verification [implementation](https://github.com/faye/faye-websocket-ruby#secure-sockets) in [faye-websocket-ruby](https://github.com/faye/faye-websocket-ruby). This PR switches off the verification to make Solana RPC Client work with WebSocket Secure endpoints secured by wildcard TLS certificates.